### PR TITLE
Escape double-underscore for `__init__.py`

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -45,7 +45,9 @@ function createMessage(pytestResult: any): string {
         const tabOfText = lineOfText[i].split(/\s+/)
         for (const t in tabOfText) {
           if (tabOfText[t] !== '') {
-            tabOfText[t] = `| ${tabOfText[t]}`
+            // Handle __init__.py 
+            const escapedText = tabOfText[t].replaceAll('__', '\\_\\_');
+            tabOfText[t] = `| ${escapedText}`
           } else {
             delete tabOfText[t]
           }


### PR DESCRIPTION
Hi, 

Thanks for making this action - it's great. 

This is a small PR to escape underscores in the Python filenames. Without this change, `__init__.py` files show up as __init__.py files, which is a minor UI issue - it's because markdown treats double-underscore as bold. 

I think this should work! I'm not sure what the testing process is. 

Thanks, 

Tom